### PR TITLE
Added support for passing defines list to ispc rules, also added linu…

### DIFF
--- a/ispc.bzl
+++ b/ispc.bzl
@@ -1,15 +1,21 @@
-def ispc_cc_library(name, out, ispc_main_source_file, srcs, target_compatible_with = [], **kwargs):
+def ispc_cc_library(name, out, ispc_main_source_file, srcs, defines, target_compatible_with = [], **kwargs):
     generted_header_filename = out
+
+    ispc_defines_list = ""
+    if len(defines) <= 1:
+        ispc_defines_list = " -D".join(defines)
+    else:
+        ispc_defines_list = "-D" + " -D".join(defines)
 
     native.genrule(
         name = "%s_ispc_gen" % name,
         srcs = srcs,
         outs = [name + ".o", generted_header_filename],
         cmd = select({
-            "@platforms//os:linux": "$(location @ispc_linux_x86_64//:ispc) --target=avx2 --arch=x86-64 --addressing=64 --pic $(locations %s) --header-outfile=$(location %s) -o $(location %s.o)" % (ispc_main_source_file, generted_header_filename, name),
-            "@rules_ispc//:osx_arm64": "$(location @ispc_osx_x86_64//:ispc) --target=neon --target-os=macos --arch=aarch64 --addressing=64 --pic $(locations %s) --header-outfile=$(location %s) -o $(location %s.o)" % (ispc_main_source_file, generted_header_filename, name),
-            "@rules_ispc//:osx_x86_64": "$(location @ispc_osx_x86_64//:ispc) --target=sse2 --target-os=macos --arch=x86-64 --addressing=64 --pic $(locations %s) --header-outfile=$(location %s) -o $(location %s.o)" % (ispc_main_source_file, generted_header_filename, name),
-            "@platforms//os:windows": "$(location @ispc_windows_x86_64//:ispc) --target=avx2 --target-os=windows --arch=x86-64 --addressing=64 $(locations %s) --header-outfile=$(location %s) -o $(location %s.o)" % (ispc_main_source_file, generted_header_filename, name),
+            "@platforms//os:linux": "$(location @ispc_linux_x86_64//:ispc) %s --target=avx2 --target-os=linux --arch=x86-64 --addressing=64 --pic $(locations %s) --header-outfile=$(location %s) -o $(location %s.o)" % (ispc_defines_list, ispc_main_source_file, generted_header_filename, name),
+            "@rules_ispc//:osx_arm64": "$(location @ispc_osx_x86_64//:ispc) %s --target=neon --target-os=macos --arch=aarch64 --addressing=64 --pic $(locations %s) --header-outfile=$(location %s) -o $(location %s.o)" % (ispc_defines_list, ispc_main_source_file, generted_header_filename, name),
+            "@rules_ispc//:osx_x86_64": "$(location @ispc_osx_x86_64//:ispc) %s --target=sse2 --target-os=macos --arch=x86-64 --addressing=64 --pic $(locations %s) --header-outfile=$(location %s) -o $(location %s.o)" % (ispc_defines_list, ispc_main_source_file, generted_header_filename, name),
+            "@platforms//os:windows": "$(location @ispc_windows_x86_64//:ispc) %s --target=avx2 --target-os=windows --arch=x86-64 --addressing=64 $(locations %s) --header-outfile=$(location %s) -o $(location %s.o)" % (ispc_defines_list, ispc_main_source_file, generted_header_filename, name),
         }),
         tools = select({
             "@platforms//os:linux": ["@ispc_linux_x86_64//:ispc"],
@@ -22,6 +28,7 @@ def ispc_cc_library(name, out, ispc_main_source_file, srcs, target_compatible_wi
         name = name,
         srcs = [name + ".o"],
         hdrs = [name + ".h"],
+        defines = defines,
         target_compatible_with = target_compatible_with,
         **kwargs
     )


### PR DESCRIPTION
Part of the fix for https://github.com/Vertexwahn/rules_oidn/issues/1

In this change the ispc_cc_library method is changed to receive an additional collection of strings that are joined in a series of define command line switches for the ispc binary.

eg. 
1. passing ["OIDN_DNNL"] produces "-DOIDN_DNNL"
2. passing ["OIDN_DNNL","OIDN_FILTER_RT"] produces "-DOIDN_DNNL -DOIDN_FILTER_RT"

Included also "--target-os=linux" for simmetry with the other platform definitions.
